### PR TITLE
Bug fix rollback compiler.ps1

### DIFF
--- a/WinToolkit.ps1
+++ b/WinToolkit.ps1
@@ -56,7 +56,7 @@ function Read-Host {
 }
 $ErrorActionPreference = 'Stop'
 try { $Host.UI.RawUI.WindowTitle = "WinToolkit by MagnetarMan" } catch {}
-$ToolkitVersion = "2.5.4 (Build 46)"
+$ToolkitVersion = "Sviluppo in Corso"
 $AppConfig = @{
     URLs            = @{
         GitHubAssetBaseUrl    = "https://raw.githubusercontent.com/Magnetarman/WinToolkit/refs/heads/main/asset/"

--- a/compiler.ps1
+++ b/compiler.ps1
@@ -240,6 +240,7 @@ Write-Host ""
 if ($Minify) {
     Write-StyledMessage 'Info' "Avvio minificazione sicura via tokenizer PowerShell."
     try {
+        $backupLines = $templateLines
         $rawContent = $templateLines -join "`n"
 
         $parseErrors = $null
@@ -288,8 +289,7 @@ if ($Minify) {
             foreach ($e in $verifyErrors) {
                 Write-StyledMessage 'Warning' "  Riga $($e.Extent.StartLineNumber): $($e.Message)."
             }
-            $templateLines = $templateLines -join "`n" | ForEach-Object { $_ }
-            $templateLines = (($templateLines) -split "`n")
+            $templateLines = $backupLines
         }
         else {
             $linesAfter = $templateLines.Count


### PR DESCRIPTION
## 🚀 Pull Request Info

| Tipo di Modifica | Dettaglio |
| :--- | :--- |
| **Branch Destinazione** | `DEV` (Obbligatorio) |
| **Issue Collegata** | Fixes # |
| **Ambito** | Pipeline CI/CD |

---

## 📝 Descrizione delle Modifiche
La logica di rollback che scatta quando la minificazione introduce errori di sintassi è implementata in modo errato. Il codice fa:

```powershell
$templateLines = $templateLines -join "`n" | ForEach-Object { $_ }
$templateLines = (($templateLines) -split "`n")
```

Questo ricostruisce l'array dall'array già modificato, non da un backup pre-minificazione. Se la minificazione produce un file non parsabile, il rollback non ripristina il contenuto originale ma opera su dati già corrotti.

**Correzione:** salvare una copia del contenuto prima della minificazione:

```powershell
$backupLines = $templateLines.Clone()
# ... minificazione ...
if ($parseErrors) { $templateLines = $backupLines }
```

--