### PR TITLE
Enhancement fix assert admin functions

### DIFF
--- a/WinToolkit.ps1
+++ b/WinToolkit.ps1
@@ -3674,7 +3674,6 @@ function VideoDriverInstall {
         }
         catch {
             Write-StyledMessage -Type 'Error' -Text "Errore durante l'impostazione del blocco download driver da Windows Update: $($_.Exception.Message)."
-            Write-StyledMessage -Type 'Warning' -Text "Potrebbe essere necessario eseguire lo script come amministratore."
             return
         }
         Write-StyledMessage -Type 'Info' -Text "Aggiornamento dei criteri di gruppo in corso per applicare le modifiche."

--- a/WinToolkit.ps1
+++ b/WinToolkit.ps1
@@ -56,7 +56,7 @@ function Read-Host {
 }
 $ErrorActionPreference = 'Stop'
 try { $Host.UI.RawUI.WindowTitle = "WinToolkit by MagnetarMan" } catch {}
-$ToolkitVersion = "2.5.4 (Build 46)"
+$ToolkitVersion = "Sviluppo in Corso"
 $AppConfig = @{
     URLs            = @{
         GitHubAssetBaseUrl    = "https://raw.githubusercontent.com/Magnetarman/WinToolkit/refs/heads/main/asset/"
@@ -2225,10 +2225,6 @@ function WinBackupDriver {
         LogsDir     = $AppConfig.Paths.DriverBackupLogs
     }
     $script:FinalArchivePath = "$($script:BackupConfig.DesktopPath)\$($script:BackupConfig.ArchiveName)_$($script:BackupConfig.DateTime).7z"
-    function Test-AdministratorPrivilege {
-        $principal = New-Object Security.Principal.WindowsPrincipal([Security.Principal.WindowsIdentity]::GetCurrent())
-        return $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
-    }
     function Initialize-BackupEnvironment {
         Write-StyledMessage -Type 'Info' -Text "🗂️ Inizializzazione ambiente backup."
         try {
@@ -2360,13 +2356,6 @@ function WinBackupDriver {
         }
     }
     try {
-        if (-not (Test-AdministratorPrivilege)) {
-            Write-StyledMessage -Type 'Error' -Text "❌ Privilegi amministratore richiesti."
-            Write-StyledMessage -Type 'Info'  -Text "💡 Riavvia PowerShell come Amministratore."
-            Write-StyledMessage -Type 'Info'  -Text "`n⌨️ Premi un tasto per uscire."
-            $null = $Host.UI.RawUI.ReadKey('NoEcho,IncludeKeyDown')
-            return
-        }
         Write-StyledMessage -Type 'Info' -Text "🚀 Inizializzazione sistema."
         Start-Sleep -Seconds 1
         if (-not (Initialize-BackupEnvironment)) { return }

--- a/tool/VideoDriverInstall.ps1
+++ b/tool/VideoDriverInstall.ps1
@@ -65,7 +65,6 @@ function VideoDriverInstall {
         }
         catch {
             Write-StyledMessage -Type 'Error' -Text "Errore durante l'impostazione del blocco download driver da Windows Update: $($_.Exception.Message)."
-            Write-StyledMessage -Type 'Warning' -Text "Potrebbe essere necessario eseguire lo script come amministratore."
             return
         }
 

--- a/tool/WinBackupDriver.ps1
+++ b/tool/WinBackupDriver.ps1
@@ -28,11 +28,6 @@ function WinBackupDriver {
 
     # ── Helper locali ─────────────────────────────────────────────────────────
 
-    function Test-AdministratorPrivilege {
-        $principal = New-Object Security.Principal.WindowsPrincipal([Security.Principal.WindowsIdentity]::GetCurrent())
-        return $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
-    }
-
     function Initialize-BackupEnvironment {
         Write-StyledMessage -Type 'Info' -Text "🗂️ Inizializzazione ambiente backup."
         try {
@@ -195,14 +190,6 @@ function WinBackupDriver {
     # ── Logica principale ─────────────────────────────────────────────────────
 
     try {
-        if (-not (Test-AdministratorPrivilege)) {
-            Write-StyledMessage -Type 'Error' -Text "❌ Privilegi amministratore richiesti."
-            Write-StyledMessage -Type 'Info'  -Text "💡 Riavvia PowerShell come Amministratore."
-            Write-StyledMessage -Type 'Info'  -Text "`n⌨️ Premi un tasto per uscire."
-            $null = $Host.UI.RawUI.ReadKey('NoEcho,IncludeKeyDown')
-            return
-        }
-
         Write-StyledMessage -Type 'Info' -Text "🚀 Inizializzazione sistema."
         Start-Sleep -Seconds 1
 


### PR DESCRIPTION
## Descrizione

- Rimozione controllo privilegi amministratore da WinBackupDriver
- Rimosso il comando Test-AdministratorPrivilege e la relativa funzione helper che verificava l'appartenenza al ruolo Administrator tramite WindowsPrincipal e WindowsBuiltInRole.
- Rimosso il blocco condizionale che, in assenza di privilegi amministrativi, interrompeva lo script mostrando un messaggio di errore e attendeva l'input di un tasto per uscire (ReadKey

---

## Tipo di Modifica

<!-- Seleziona tutti i tipi applicabili -->
- [ ] 🐛 Bug fix
- [ ] ✨ Nuova feature
- [x] ♻️ Refactoring (nessun cambio funzionale)
- [ ] 🧹 Pulizia / Manutenzione
- [ ] 📖 Documentazione

---

## File Modificati

- `WinBackupDriver.ps1`
- `VideoDriverInstall.ps1`

---

## Test & Verifica

- [ ] Verificato localmente tramite `compiler.ps1`
- [ ] Log di esecuzione allegati (snippet o screenshot)

<details>
<summary>Log / Screenshot</summary>

```
Incolla qui i log rilevanti
```

</details>

---

## Checklist

> L'assenza di una spunta o la violazione di una regola comporta il rifiuto automatico della PR.

- [x] PR indirizzata a `DEV` — le PR verso `main` vengono chiuse immediatamente
- [x] Modifica atomica: un solo problema o una sola feature per PR
- [x] `WinToolkit.ps1` **non** modificato manualmente (gestito dall'automazione CI)
- [x] Modificati solo file in `/tool/*.ps1` o `WinToolkit-template.ps1`
- [x] Stile di codice esistente rispettato, nessun debug code lasciato
- [x] Commit chiari in italiano, max 72 caratteri per riga
