### PR TITLE
Fix encoding BOM UTF-8

### DIFF
--- a/.github/scripts/Invoke-Build.ps1
+++ b/.github/scripts/Invoke-Build.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Compila WinToolkit.ps1 da WinToolkit-template.ps1 e i file in /tool.
 

--- a/.github/scripts/New-ReleaseNotes.ps1
+++ b/.github/scripts/New-ReleaseNotes.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Genera le release notes aggregando PR e Issue chiuse dall'ultima release stabile.
 

--- a/.github/scripts/Test-CompiledScript.ps1
+++ b/.github/scripts/Test-CompiledScript.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Valida il file WinToolkit.ps1 compilato.
 

--- a/.github/scripts/Update-Version.ps1
+++ b/.github/scripts/Update-Version.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Incrementa il numero di build nel template WinToolkit.
 

--- a/.github/tests/Integration/Build.Tests.ps1
+++ b/.github/tests/Integration/Build.Tests.ps1
@@ -1,4 +1,4 @@
-#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
+﻿#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
 <#
 .SYNOPSIS
     Integration test della pipeline di compilazione.

--- a/.github/tests/Unit/GamingToolkit.Tests.ps1
+++ b/.github/tests/Unit/GamingToolkit.Tests.ps1
@@ -1,4 +1,4 @@
-#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
+﻿#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
 <#
 .SYNOPSIS
     Unit test per il modulo GamingToolkit.

--- a/.github/tests/Unit/WinCleaner.Tests.ps1
+++ b/.github/tests/Unit/WinCleaner.Tests.ps1
@@ -1,4 +1,4 @@
-#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
+﻿#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
 <#
 .SYNOPSIS
     Unit test per il modulo WinCleaner.

--- a/.github/tests/WinToolkit.Tests.ps1
+++ b/.github/tests/WinToolkit.Tests.ps1
@@ -1,4 +1,4 @@
-#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
+﻿#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
 <#
 .SYNOPSIS
     Suite di test Pester 5 per le funzioni core di WinToolkit.

--- a/WinToolkit-template.ps1
+++ b/WinToolkit-template.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     WinToolkit - Sopravvivi a Windows
 .DESCRIPTION
@@ -55,7 +55,8 @@ function Read-Host {
                     foreach ($char in $inputString.ToCharArray()) { $secure.AppendChar($char) }
                     return $secure
                 }
-                return $inputString ?? ""
+                if ($null -eq $inputString) { return "" }
+                return $inputString
             }
             if ($keyInfo.Key -eq "Backspace") {
                 if ($inputString.Length -gt 0) {
@@ -611,7 +612,8 @@ function Show-ConsoleTable {
             $line += ' ' + $val.PadRight($widths[$col.Key]) + ' |'
         }
         $rowColor = 'White'
-        $statusKey = ($Columns | Where-Object { $_.Key -eq 'Status' -or $_.Key -eq 'Stato' } | Select-Object -First 1)?.Key
+        $statusColumn = $Columns | Where-Object { $_.Key -eq 'Status' -or $_.Key -eq 'Stato' } | Select-Object -First 1
+        $statusKey = if ($statusColumn) { $statusColumn.Key } else { $null }
         if ($statusKey) {
             $statusVal = if ($row -is [hashtable]) { "$($row[$statusKey])" } else { "$($row.$statusKey)" }
             if ($statusVal -match '✅|OK|Successo|Completato') { $rowColor = 'Green' }
@@ -1403,7 +1405,7 @@ function Get-WingetExecutable {
     $aliasPath = Join-Path $env:LOCALAPPDATA "Microsoft\WindowsApps\winget.exe"
     if (Test-Path $aliasPath) { return $aliasPath }
 
-    $arch = [Environment]::Is64BitOperatingSystem ? "x64" : "x86"
+    $arch = if ([Environment]::Is64BitOperatingSystem) { "x64" } else { "x86" }
     $wingetDir = Get-ChildItem -Path "$env:ProgramFiles\WindowsApps" `
         -Filter "Microsoft.DesktopAppInstaller_*_*${arch}__8wekyb3d8bbwe" -ErrorAction SilentlyContinue |
     Sort-Object Name -Descending | Select-Object -First 1
@@ -1427,7 +1429,7 @@ function Start-AppxSilentProcess {
         [string[]]$DependencyPaths = @()
     )
 
-    $pathParam = ($Flags -match '-Register') ? "" : "-Path '$($AppxPath -replace "'", "''")'"
+    $pathParam = if ($Flags -match '-Register') { "" } else { "-Path '$($AppxPath -replace "'", "''")'" }
     $depString = ""
     if ($DependencyPaths.Count -gt 0) {
         $depString = "-DependencyPackagePath " + (($DependencyPaths | ForEach-Object { "'$($_ -replace "'", "''")'" }) -join ", ")
@@ -1551,7 +1553,8 @@ function Reset-Winget {
         try {
             $latest = Invoke-RestMethod -Uri "https://api.github.com/repos/microsoft/winget-cli/releases/latest" -UseBasicParsing -ErrorAction Stop
             $asset = $latest.assets | Where-Object { $_.name -match $Match } | Select-Object -First 1
-            return $asset ? $asset.browser_download_url : $null
+            if ($asset) { return $asset.browser_download_url }
+            return $null
         }
         catch { return $null }
     }
@@ -1631,7 +1634,7 @@ function Reset-Winget {
     function _Set-WingetPathPermissions {
         $wingetFolderPath = $null
         try {
-            $arch = [Environment]::Is64BitOperatingSystem ? 'x64' : 'x86'
+            $arch = if ([Environment]::Is64BitOperatingSystem) { 'x64' } else { 'x86' }
             $wingetDir = Get-ChildItem "$env:ProgramFiles\WindowsApps" `
                 -Filter "Microsoft.DesktopAppInstaller_*_*${arch}__8wekyb3d8bbwe" -ErrorAction SilentlyContinue |
             Sort-Object Name -Descending | Select-Object -First 1
@@ -1816,7 +1819,7 @@ function Reset-Winget {
 
         if (-not (_Test-VCRedistInstalled) -or $Force) {
             Write-StyledMessage -Type Info -Text "Installazione Visual C++ Redistributable..."
-            $arch = [Environment]::Is64BitOperatingSystem ? "x64" : "x86"
+            $arch = if ([Environment]::Is64BitOperatingSystem) { "x64" } else { "x86" }
             $vcUrl = "https://aka.ms/vs/17/release/vc_redist.$arch.exe"
             $vcFile = Join-Path $AppConfig.Paths.Temp "vc_redist.exe"
             if (-not (Test-Path $AppConfig.Paths.Temp)) { $null = New-Item $AppConfig.Paths.Temp -ItemType Directory -Force }
@@ -1832,7 +1835,7 @@ function Reset-Winget {
             $depDir = Join-Path $AppConfig.Paths.Temp "deps"
             Invoke-WebRequest -Uri $depUrl -OutFile $depZip -UseBasicParsing
             Expand-Archive -Path $depZip -DestinationPath $depDir -Force
-            $archPattern = [Environment]::Is64BitOperatingSystem ? "x64|ne" : "x86|ne"
+            $archPattern = if ([Environment]::Is64BitOperatingSystem) { "x64|ne" } else { "x86|ne" }
             $script:WingetDependencies = @()
             Get-ChildItem $depDir -Recurse -Filter "*.appx" |
             Where-Object { $_.Name -match $archPattern } |

--- a/WinToolkit_GUI.ps1
+++ b/WinToolkit_GUI.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     WinToolkit GUI v3.0
 .DESCRIPTION

--- a/assets/Microsoft.PowerShell_profile.ps1
+++ b/assets/Microsoft.PowerShell_profile.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Profilo PowerShell
 

--- a/compiler.ps1
+++ b/compiler.ps1
@@ -363,8 +363,8 @@ try {
     
     if (Test-Path $outputFile) { Remove-Item $outputFile -Force -ErrorAction Stop }
     
-    $utf8NoBom = New-Object System.Text.UTF8Encoding $false
-    [System.IO.File]::WriteAllLines($outputFile, $templateLines, $utf8NoBom)
+    $utf8Bom = New-Object System.Text.UTF8Encoding $true
+    [System.IO.File]::WriteAllLines($outputFile, $templateLines, $utf8Bom)
     
 }
 catch {

--- a/compiler.ps1
+++ b/compiler.ps1
@@ -1,4 +1,4 @@
-# Script di compilazione per WinToolkit (Enterprise-Grade)
+﻿# Script di compilazione per WinToolkit (Enterprise-Grade)
 # Gestisce aggregazione moduli, logging strutturato e minificazione del codice.
 
 [CmdletBinding()]

--- a/start-offline.ps1
+++ b/start-offline.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Script di Start per Win Toolkit in modalità Offline.
 .DESCRIPTION

--- a/start.ps1
+++ b/start.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Script di inizio che installa e configura WinToolkit.
 .DESCRIPTION

--- a/tools/AutoVideoDriverInstall.ps1
+++ b/tools/AutoVideoDriverInstall.ps1
@@ -1,4 +1,4 @@
-function AutoVideoDriverInstall {
+﻿function AutoVideoDriverInstall {
     <#
     .SYNOPSIS
         Installazione automatica driver video con rilevamento GPU (AMD/NVIDIA/Intel).

--- a/tools/DisableBitlocker.ps1
+++ b/tools/DisableBitlocker.ps1
@@ -1,4 +1,4 @@
-function DisableBitlocker {
+﻿function DisableBitlocker {
     <#
     .SYNOPSIS
         Disattiva BitLocker sul drive C: e previene la crittografia futura.

--- a/tools/GamingToolkit.ps1
+++ b/tools/GamingToolkit.ps1
@@ -1,4 +1,4 @@
-function GamingToolkit {
+﻿function GamingToolkit {
     <#
     .SYNOPSIS
         Gaming Toolkit - Strumenti di ottimizzazione per il gaming su Windows.
@@ -171,7 +171,9 @@ function GamingToolkit {
         else {
             $exitCode = if ($result -is [hashtable] -and $result.Contains('ExitCode')) { $result.ExitCode } else { -1 }
             $successCodes = @(0, 3010, 5100, -9, 9, -1442840576)
-            Write-StyledMessage -Type ($exitCode -in $successCodes ? 'Success' : 'Error') -Text ($exitCode -in $successCodes ? "DirectX installato (codice: $exitCode)." : "DirectX errore: $exitCode")
+            $messageType = if ($exitCode -in $successCodes) { 'Success' } else { 'Error' }
+            $messageText = if ($exitCode -in $successCodes) { "DirectX installato (codice: $exitCode)." } else { "DirectX errore: $exitCode" }
+            Write-StyledMessage -Type $messageType -Text $messageText
         }
     }
     catch {
@@ -258,7 +260,9 @@ function GamingToolkit {
         }
         else {
             $exitCode = if ($result -is [hashtable] -and $result.Contains('ExitCode')) { $result.ExitCode } else { -1 }
-            Write-StyledMessage -Type ($exitCode -in @(0, 3010) ? 'Success' : 'Warning') -Text ($exitCode -in @(0, 3010) ? "Battle.net installato." : "Battle.net: codice $exitCode")
+            $messageType = if ($exitCode -in @(0, 3010)) { 'Success' } else { 'Warning' }
+            $messageText = if ($exitCode -in @(0, 3010)) { "Battle.net installato." } else { "Battle.net: codice $exitCode" }
+            Write-StyledMessage -Type $messageType -Text $messageText
         }
 
         Write-StyledMessage -Type 'Info' -Text 'Premi un tasto per continuare.'

--- a/tools/Install-Office.ps1
+++ b/tools/Install-Office.ps1
@@ -1,4 +1,4 @@
-function Install-Office {
+﻿function Install-Office {
     <#
     .SYNOPSIS
         Installa Microsoft Office Basic tramite ODT (Office Deployment Tool).

--- a/tools/Repair-Office.ps1
+++ b/tools/Repair-Office.ps1
@@ -1,4 +1,4 @@
-function Repair-Office {
+﻿function Repair-Office {
     <#
     .SYNOPSIS
         Ripara Microsoft Office tramite Click-to-Run (riparazione rapida + fallback online).
@@ -42,9 +42,9 @@ function Repair-Office {
         }
         if ($cleanedCount -gt 0) { Write-StyledMessage -Type 'Success' -Text "$cleanedCount cache eliminate." }
 
-        $officeClient = (Test-Path "${env:ProgramFiles}\Common Files\microsoft shared\ClickToRun\OfficeClickToRun.exe") ?
-            "${env:ProgramFiles}\Common Files\microsoft shared\ClickToRun\OfficeClickToRun.exe" :
-            "${env:ProgramFiles(x86)}\Common Files\microsoft shared\ClickToRun\OfficeClickToRun.exe"
+        $officeClient64 = "${env:ProgramFiles}\Common Files\microsoft shared\ClickToRun\OfficeClickToRun.exe"
+        $officeClient32 = "${env:ProgramFiles(x86)}\Common Files\microsoft shared\ClickToRun\OfficeClickToRun.exe"
+        $officeClient = if (Test-Path $officeClient64) { $officeClient64 } else { $officeClient32 }
 
         if (-not (Test-Path $officeClient)) {
             Write-StyledMessage -Type 'Error' -Text "OfficeClickToRun.exe non trovato. Office potrebbe non essere installato."

--- a/tools/Uninstall-Office.ps1
+++ b/tools/Uninstall-Office.ps1
@@ -1,4 +1,4 @@
-function Uninstall-Office {
+﻿function Uninstall-Office {
     <#
     .SYNOPSIS
         Rimuove completamente Microsoft Office. Usa Get Help su Win11 23H2+, rimozione diretta su versioni precedenti.
@@ -22,7 +22,9 @@ function Uninstall-Office {
     function Get-WindowsVersion {
         try {
             $buildNumber = [int](Get-CimInstance -ClassName Win32_OperatingSystem).BuildNumber
-            return $buildNumber -ge 22631 ? "Windows11_23H2_Plus" : ($buildNumber -ge 22000 ? "Windows11_22H2_Or_Older" : "Windows10_Or_Older")
+            if ($buildNumber -ge 22631) { return "Windows11_23H2_Plus" }
+            if ($buildNumber -ge 22000) { return "Windows11_22H2_Or_Older" }
+            return "Windows10_Or_Older"
         }
         catch {
             Write-StyledMessage -Type 'Warning' -Text "Impossibile rilevare versione Windows: $_"

--- a/tools/VideoDriverReinstall.ps1
+++ b/tools/VideoDriverReinstall.ps1
@@ -1,4 +1,4 @@
-function VideoDriverReinstall {
+﻿function VideoDriverReinstall {
     <#
     .SYNOPSIS
         Reinstallazione/riparazione driver video tramite DDU in modalità provvisoria.

--- a/tools/WinBackupDriver.ps1
+++ b/tools/WinBackupDriver.ps1
@@ -1,4 +1,4 @@
-function WinBackupDriver {
+﻿function WinBackupDriver {
     <#
     .SYNOPSIS
         Backup completo dei driver di sistema Windows.

--- a/tools/WinCleaner.ps1
+++ b/tools/WinCleaner.ps1
@@ -1,4 +1,4 @@
-function WinCleaner {
+﻿function WinCleaner {
     <#
     .SYNOPSIS
         Script automatico per la pulizia completa del sistema Windows.
@@ -86,7 +86,9 @@ function WinCleaner {
             }
 
             $isSuccess = ($result.ExitCode -eq 0)
-            Add-CleanerLog -Type ($isSuccess ? 'Info' : 'Warning') -Text ($isSuccess ? "Comando completato." : "Comando completato con codice $($result.ExitCode)")
+            $messageType = if ($isSuccess) { 'Info' } else { 'Warning' }
+            $messageText = if ($isSuccess) { "Comando completato." } else { "Comando completato con codice $($result.ExitCode)" }
+            Add-CleanerLog -Type $messageType -Text $messageText
             return $true
         }
         catch {

--- a/tools/WinDebloat.ps1
+++ b/tools/WinDebloat.ps1
@@ -1,4 +1,4 @@
-function WinDebloat {
+﻿function WinDebloat {
     <#
     .SYNOPSIS
         Ottimizzazione del sistema tramite disabilitazione di servizi non necessari.

--- a/tools/WinDeleteUserProfiles.ps1
+++ b/tools/WinDeleteUserProfiles.ps1
@@ -1,4 +1,4 @@
-function WinDeleteUserProfiles {
+﻿function WinDeleteUserProfiles {
     <#
     .SYNOPSIS
         Rimuove in modo sicuro i profili utente locali non caricati e le cartelle residue in C:\Users.

--- a/tools/WinExportLog.ps1
+++ b/tools/WinExportLog.ps1
@@ -1,4 +1,4 @@
-function WinExportLog {
+﻿function WinExportLog {
     <#
     .SYNOPSIS
         Comprime i log di WinToolkit e li salva sul desktop per l'invio diagnostico.

--- a/tools/WinReinstallStore.ps1
+++ b/tools/WinReinstallStore.ps1
@@ -1,4 +1,4 @@
-function WinReinstallStore {
+﻿function WinReinstallStore {
     <#
     .SYNOPSIS
         Reinstalla automaticamente il Microsoft Store su Windows 10/11 utilizzando Winget.

--- a/tools/WinRepairToolkit.ps1
+++ b/tools/WinRepairToolkit.ps1
@@ -1,4 +1,4 @@
-function WinRepairToolkit {
+﻿function WinRepairToolkit {
     <#
     .SYNOPSIS
         Esegue riparazioni standard di Windows (SFC, DISM, Chkdsk) e salva i log di Scannow nella cartella del Toolkit debug addizionale.
@@ -57,7 +57,8 @@ function WinRepairToolkit {
             $commandToRun = $Config.Tool
             $argsToRun = $Config.Args
             if ($isChkdsk -and ($Config.Args -contains '/f' -or $Config.Args -contains '/r')) {
-                $drive = ($Config.Args | Where-Object { $_ -match '^[A-Za-z]:$' } | Select-Object -First 1) ?? $env:SystemDrive
+                $drive = $Config.Args | Where-Object { $_ -match '^[A-Za-z]:$' } | Select-Object -First 1
+                if ($null -eq $drive) { $drive = $env:SystemDrive }
                 $filteredArgs = $Config.Args | Where-Object { $_ -notmatch '^[A-Za-z]:$' }
                 $commandToRun = 'cmd.exe'
                 $argsToRun = @('/c', "echo Y| chkdsk $drive $($filteredArgs -join ' ')")

--- a/tools/WinUpdateReset.ps1
+++ b/tools/WinUpdateReset.ps1
@@ -1,4 +1,4 @@
-function WinUpdateReset {
+﻿function WinUpdateReset {
     <#
     .SYNOPSIS
         Ripara i componenti di Windows Update, reimposta servizi, registro e criteri di default.
@@ -90,8 +90,8 @@ function WinUpdateReset {
                     }
                 }
                 'Check' {
-                    $status = ($service.Status -eq 'Running') ? '🟢 Attivo' : '🔴 Inattivo'
-                    $serviceIcon = $config.Icon ?? '⚙️'
+                    $status = if ($service.Status -eq 'Running') { '🟢 Attivo' } else { '🔴 Inattivo' }
+                    $serviceIcon = if ($null -ne $config.Icon) { $config.Icon } else { '⚙️' }
                     Write-StyledMessage -Type 'Info' -Text "$serviceIcon $serviceName - Stato: $status"
                 }
             }
@@ -486,7 +486,7 @@ function WinUpdateReset {
         foreach ($service in $verificationServices) {
             $svc = Get-Service -Name $service -ErrorAction SilentlyContinue
             if ($svc) {
-                $status = ($svc.Status -eq 'Running') ? '🟢 ATTIVO' : '🔴 INATTIVO'
+                $status = if ($svc.Status -eq 'Running') { '🟢 ATTIVO' } else { '🔴 INATTIVO' }
                 $startup = $svc.StartType
                 Write-StyledMessage -Type 'Info' -Text "📊 $service - Stato: $status | Avvio: $startup."
             }


### PR DESCRIPTION
## Descrizione

<!-- Spiega cosa cambia e perché. Sii conciso ma completo. -->
File parse OK se letto UTF-8 esplicito, ma PowerShell 5.1 può leggerlo male senza BOM. Risultato: emoji diventano mojibake e parser esplode.
Aggiunto BOM UTF-8 (EF BB BF) a tutti i file .ps1.
Sostituita la sintassi di alcuni file .ps1 per renderla compatibile a PowerShell 5.1.
Impostata a true la codifica BOM UTF-8 in compiler.ps1.

---

## Tipo di Modifica

<!-- Seleziona tutti i tipi applicabili -->
- [x] 🐛 Bug fix
- [ ] ✨ Nuova feature
- [x] ♻️ Refactoring (nessun cambio funzionale)
- [ ] 🧹 Pulizia / Manutenzione
- [ ] 📖 Documentazione

---

## File Modificati

<!-- Elenca ogni file con una riga di descrizione -->
- `compiler.ps1` — Impostato encoding BOM UTF-8 a true.
- `WinToolkit-template.ps1` — Refactor sintassi in formato compatibile con PS 5.1.
- `tools/GamingToolkit.ps1` — Refactor sintassi in formato compatibile con PS 5.1.
- `tools/Repair-Office.ps1` — Refactor sintassi in formato compatibile con PS 5.1.
- `tools/Uninstall-Office.ps1` — Refactor sintassi in formato compatibile con PS 5.1.
- `tools/WinCleaner.ps1` — Refactor sintassi in formato compatibile con PS 5.1.
- `tools/WinRepairToolkit.ps1` — Refactor sintassi in formato compatibile con PS 5.1.
- `tools/WinUpdateReset.ps1` — Refactor sintassi in formato compatibile con PS 5.1.
- `*.ps1` — Fix encoding BOM UTF-8.

---

## Test & Verifica

- [x] Verificato localmente tramite `compiler.ps1`
- [ ] Log di esecuzione allegati (snippet o screenshot)

<details>
<summary>Log / Screenshot</summary>

```
Incolla qui i log rilevanti
```

</details>

---

## Checklist

> L'assenza di una spunta o la violazione di una regola comporta il rifiuto automatico della PR.

- [x] PR indirizzata a `DEV` — le PR verso `main` vengono chiuse immediatamente
- [ ] Modifica atomica: un solo problema o una sola feature per PR
- [x] `WinToolkit.ps1` **non** modificato manualmente (gestito dall'automazione CI)
- [ ] Modificati solo file in `/tool/*.ps1` o `WinToolkit-template.ps1`
- [ ] Stile di codice esistente rispettato, nessun debug code lasciato
- [x] Commit chiari in italiano, max 72 caratteri per riga
