### PR TITLE
Bug wintoolkit not start

### DIFF
--- a/.github/scripts/Invoke-Build.ps1
+++ b/.github/scripts/Invoke-Build.ps1
@@ -1,4 +1,4 @@
-﻿<#
+<#
 .SYNOPSIS
     Compila WinToolkit.ps1 da WinToolkit-template.ps1 e i file in /tool.
 

--- a/.github/scripts/New-ReleaseNotes.ps1
+++ b/.github/scripts/New-ReleaseNotes.ps1
@@ -1,4 +1,4 @@
-﻿<#
+<#
 .SYNOPSIS
     Genera le release notes aggregando PR e Issue chiuse dall'ultima release stabile.
 

--- a/.github/scripts/Test-CompiledScript.ps1
+++ b/.github/scripts/Test-CompiledScript.ps1
@@ -1,4 +1,4 @@
-﻿<#
+<#
 .SYNOPSIS
     Valida il file WinToolkit.ps1 compilato.
 

--- a/.github/scripts/Update-Version.ps1
+++ b/.github/scripts/Update-Version.ps1
@@ -1,4 +1,4 @@
-﻿<#
+<#
 .SYNOPSIS
     Incrementa il numero di build nel template WinToolkit.
 

--- a/.github/tests/Integration/Build.Tests.ps1
+++ b/.github/tests/Integration/Build.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
 <#
 .SYNOPSIS
     Integration test della pipeline di compilazione.

--- a/.github/tests/Unit/GamingToolkit.Tests.ps1
+++ b/.github/tests/Unit/GamingToolkit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
 <#
 .SYNOPSIS
     Unit test per il modulo GamingToolkit.

--- a/.github/tests/Unit/WinCleaner.Tests.ps1
+++ b/.github/tests/Unit/WinCleaner.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
 <#
 .SYNOPSIS
     Unit test per il modulo WinCleaner.

--- a/.github/tests/WinToolkit.Tests.ps1
+++ b/.github/tests/WinToolkit.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.0.0' }
 <#
 .SYNOPSIS
     Suite di test Pester 5 per le funzioni core di WinToolkit.

--- a/WinToolkit-template.ps1
+++ b/WinToolkit-template.ps1
@@ -180,7 +180,8 @@ $Global:ToolkitLanguage = 'en-US'
 $Global:ToolkitLanguageData = $null
 $Global:ToolkitDefaultLanguageData = $null
 function Get-ToolkitLanguageDirectory {
-    $candidate = Join-Path $PSScriptRoot 'languages'
+    $root = if ($PSScriptRoot) { $PSScriptRoot } else { (Get-Location).Path }
+    $candidate = Join-Path $root 'languages'
     if (Test-Path $candidate) { return $candidate }
 
     $repoCandidate = Join-Path (Get-Location) 'languages'

--- a/WinToolkit-template.ps1
+++ b/WinToolkit-template.ps1
@@ -1,4 +1,4 @@
-﻿<#
+<#
 .SYNOPSIS
     WinToolkit - Sopravvivi a Windows
 .DESCRIPTION

--- a/WinToolkit.ps1
+++ b/WinToolkit.ps1
@@ -57,7 +57,7 @@ function Read-Host {
 }
 $ErrorActionPreference = 'Stop'
 try { $Host.UI.RawUI.WindowTitle = "WinToolkit by MagnetarMan" } catch {}
-$ToolkitVersion = "2.5.5 (Build 4)"
+$ToolkitVersion = "Sviluppo in Corso"
 $AppConfig = @{
     URLs            = @{
         GitHubAssetBaseUrl    = "https://raw.githubusercontent.com/Magnetarman/WinToolkit/refs/heads/main/assets/"

--- a/WinToolkit.ps1
+++ b/WinToolkit.ps1
@@ -134,7 +134,8 @@ $Global:ToolkitLanguage = 'en-US'
 $Global:ToolkitLanguageData = $null
 $Global:ToolkitDefaultLanguageData = $null
 function Get-ToolkitLanguageDirectory {
-    $candidate = Join-Path $PSScriptRoot 'languages'
+    $root = if ($PSScriptRoot) { $PSScriptRoot } else { (Get-Location).Path }
+    $candidate = Join-Path $root 'languages'
     if (Test-Path $candidate) { return $candidate }
     $repoCandidate = Join-Path (Get-Location) 'languages'
     if (Test-Path $repoCandidate) { return $repoCandidate }

--- a/WinToolkit.ps1
+++ b/WinToolkit.ps1
@@ -1,4 +1,4 @@
-﻿param([int]$CountdownSeconds = 30, [switch]$ImportOnly, [string]$Language = 'en-US')
+param([int]$CountdownSeconds = 30, [switch]$ImportOnly, [string]$Language = 'en-US')
 function Read-Host {
     [CmdletBinding()]
     param(

--- a/WinToolkit_GUI.ps1
+++ b/WinToolkit_GUI.ps1
@@ -1,4 +1,4 @@
-﻿<#
+<#
 .SYNOPSIS
     WinToolkit GUI v3.0
 .DESCRIPTION

--- a/WinToolkit_GUI.ps1
+++ b/WinToolkit_GUI.ps1
@@ -156,7 +156,8 @@ $Global:ToolkitDefaultLanguageData = $null
 # =============================================================================
 
 function Get-ToolkitLanguageDirectory {
-    $candidate = Join-Path $PSScriptRoot 'languages'
+    $root = if ($PSScriptRoot) { $PSScriptRoot } else { (Get-Location).Path }
+    $candidate = Join-Path $root 'languages'
     if (Test-Path $candidate) { return $candidate }
 
     $repoCandidate = Join-Path (Get-Location) 'languages'

--- a/assets/Microsoft.PowerShell_profile.ps1
+++ b/assets/Microsoft.PowerShell_profile.ps1
@@ -1,4 +1,4 @@
-﻿<#
+<#
 .SYNOPSIS
     Profilo PowerShell
 

--- a/compiler.ps1
+++ b/compiler.ps1
@@ -1,4 +1,4 @@
-﻿# Script di compilazione per WinToolkit (Enterprise-Grade)
+# Script di compilazione per WinToolkit (Enterprise-Grade)
 # Gestisce aggregazione moduli, logging strutturato e minificazione del codice.
 
 [CmdletBinding()]
@@ -379,8 +379,8 @@ try {
     
     if (Test-Path $outputFile) { Remove-Item $outputFile -Force -ErrorAction Stop }
     
-    $utf8Bom = New-Object System.Text.UTF8Encoding $true
-    [System.IO.File]::WriteAllLines($outputFile, $templateLines, $utf8Bom)
+    $utf8NoBom = New-Object System.Text.UTF8Encoding $false
+    [System.IO.File]::WriteAllLines($outputFile, $templateLines, $utf8NoBom)
     
 }
 catch {

--- a/languages/ar-SA/WinToolkit.psd1
+++ b/languages/ar-SA/WinToolkit.psd1
@@ -1,4 +1,4 @@
-﻿# culture="ar-SA"
+# culture="ar-SA"
 ConvertFrom-StringData -StringData @'
 language.code = ar-SA
 language.name = Arabic

--- a/languages/bn-BD/WinToolkit.psd1
+++ b/languages/bn-BD/WinToolkit.psd1
@@ -1,4 +1,4 @@
-﻿# culture="bn-BD"
+# culture="bn-BD"
 ConvertFrom-StringData -StringData @'
 language.code = bn-BD
 language.name = Bengali

--- a/languages/en-US/WinToolkit.psd1
+++ b/languages/en-US/WinToolkit.psd1
@@ -1,4 +1,4 @@
-﻿# culture="en-US"
+# culture="en-US"
 ConvertFrom-StringData -StringData @'
 language.code = en-US
 language.name = English

--- a/languages/es-ES/WinToolkit.psd1
+++ b/languages/es-ES/WinToolkit.psd1
@@ -1,4 +1,4 @@
-﻿# culture="es-ES"
+# culture="es-ES"
 ConvertFrom-StringData -StringData @'
 language.code = es-ES
 language.name = Spanish

--- a/languages/fr-FR/WinToolkit.psd1
+++ b/languages/fr-FR/WinToolkit.psd1
@@ -1,4 +1,4 @@
-﻿# culture="fr-FR"
+# culture="fr-FR"
 ConvertFrom-StringData -StringData @'
 language.code = fr-FR
 language.name = French

--- a/languages/hi-IN/WinToolkit.psd1
+++ b/languages/hi-IN/WinToolkit.psd1
@@ -1,4 +1,4 @@
-﻿# culture="hi-IN"
+# culture="hi-IN"
 ConvertFrom-StringData -StringData @'
 language.code = hi-IN
 language.name = Hindi

--- a/languages/id-ID/WinToolkit.psd1
+++ b/languages/id-ID/WinToolkit.psd1
@@ -1,4 +1,4 @@
-﻿# culture="id-ID"
+# culture="id-ID"
 ConvertFrom-StringData -StringData @'
 language.code = id-ID
 language.name = Indonesian

--- a/languages/it-IT/WinToolkit.psd1
+++ b/languages/it-IT/WinToolkit.psd1
@@ -1,4 +1,4 @@
-﻿# culture="it-IT"
+# culture="it-IT"
 ConvertFrom-StringData -StringData @'
 language.code = it-IT
 language.name = Italian

--- a/languages/pt-BR/WinToolkit.psd1
+++ b/languages/pt-BR/WinToolkit.psd1
@@ -1,4 +1,4 @@
-﻿# culture="pt-BR"
+# culture="pt-BR"
 ConvertFrom-StringData -StringData @'
 language.code = pt-BR
 language.name = Portuguese

--- a/languages/ru-RU/WinToolkit.psd1
+++ b/languages/ru-RU/WinToolkit.psd1
@@ -1,4 +1,4 @@
-﻿# culture="ru-RU"
+# culture="ru-RU"
 ConvertFrom-StringData -StringData @'
 language.code = ru-RU
 language.name = Russian

--- a/languages/ur-PK/WinToolkit.psd1
+++ b/languages/ur-PK/WinToolkit.psd1
@@ -1,4 +1,4 @@
-﻿# culture="ur-PK"
+# culture="ur-PK"
 ConvertFrom-StringData -StringData @'
 language.code = ur-PK
 language.name = Urdu

--- a/languages/zh-CN/WinToolkit.psd1
+++ b/languages/zh-CN/WinToolkit.psd1
@@ -1,4 +1,4 @@
-﻿# culture="zh-CN"
+# culture="zh-CN"
 ConvertFrom-StringData -StringData @'
 language.code = zh-CN
 language.name = Chinese Simplified

--- a/start-offline.ps1
+++ b/start-offline.ps1
@@ -1,4 +1,4 @@
-﻿<#
+<#
 .SYNOPSIS
     Script di Start per Win Toolkit in modalità Offline.
 .DESCRIPTION

--- a/start-offline.ps1
+++ b/start-offline.ps1
@@ -21,9 +21,10 @@ $script:SourceTextLanguageData = $null
 $script:SourceTextDefaultLanguageData = $null
 
 function Get-SourceTextLanguageDirectory {
+    $root = if ($PSScriptRoot) { $PSScriptRoot } else { (Get-Location).Path }
     $candidates = @(
-        (Join-Path $PSScriptRoot 'languages'),
-        (Join-Path (Split-Path $PSScriptRoot -Parent) 'languages'),
+        (Join-Path $root 'languages'),
+        (Join-Path (Split-Path $root -Parent) 'languages'),
         (Join-Path (Get-Location) 'languages')
     )
     foreach ($candidate in $candidates) {
@@ -320,7 +321,7 @@ function Prepare-OfflineResources {
 }
 
 # --- Main execution for Start-Offline.ps1 ---
-$PSScriptRoot = Split-Path -Parent $MyInvocation.MyCommand.Definition
+$PSScriptRoot = if ($MyInvocation.MyCommand.Definition) { Split-Path -Parent $MyInvocation.MyCommand.Definition } else { (Get-Location).Path }
 $OfflineResourcesDir = Join-Path $PSScriptRoot "start"
 $mainScriptPath = Join-Path $OfflineResourcesDir "start.ps1"
 

--- a/start.ps1
+++ b/start.ps1
@@ -1,4 +1,4 @@
-﻿<#
+<#
 .SYNOPSIS
     Script di inizio che installa e configura WinToolkit.
 .DESCRIPTION

--- a/start.ps1
+++ b/start.ps1
@@ -813,9 +813,10 @@ $script:SourceTextLanguageData = $null
 $script:SourceTextDefaultLanguageData = $null
 
 function Get-SourceTextLanguageDirectory {
+    $root = if ($PSScriptRoot) { $PSScriptRoot } else { (Get-Location).Path }
     $candidates = @(
-        (Join-Path $PSScriptRoot 'languages'),
-        (Join-Path (Split-Path $PSScriptRoot -Parent) 'languages'),
+        (Join-Path $root 'languages'),
+        (Join-Path (Split-Path $root -Parent) 'languages'),
         (Join-Path (Get-Location) 'languages')
     )
     foreach ($candidate in $candidates) {

--- a/tools/AutoVideoDriverInstall.ps1
+++ b/tools/AutoVideoDriverInstall.ps1
@@ -1,4 +1,4 @@
-﻿function AutoVideoDriverInstall {
+function AutoVideoDriverInstall {
     <#
     .SYNOPSIS
         Automatically installs video drivers after detecting the GPU vendor (AMD/NVIDIA/Intel).

--- a/tools/DisableBitlocker.ps1
+++ b/tools/DisableBitlocker.ps1
@@ -1,4 +1,4 @@
-﻿function DisableBitlocker {
+function DisableBitlocker {
     <#
     .SYNOPSIS
         Disattiva BitLocker sul drive C: e previene la crittografia futura.

--- a/tools/GamingToolkit.ps1
+++ b/tools/GamingToolkit.ps1
@@ -1,4 +1,4 @@
-﻿function GamingToolkit {
+function GamingToolkit {
     <#
     .SYNOPSIS
         Gaming Toolkit - Windows gaming optimization tools.

--- a/tools/Install-Office.ps1
+++ b/tools/Install-Office.ps1
@@ -1,4 +1,4 @@
-﻿function Install-Office {
+function Install-Office {
     <#
     .SYNOPSIS
         Installs Microsoft Office Basic through ODT (Office Deployment Tool).

--- a/tools/Repair-Office.ps1
+++ b/tools/Repair-Office.ps1
@@ -1,4 +1,4 @@
-﻿function Repair-Office {
+function Repair-Office {
     <#
     .SYNOPSIS
         Repairs Microsoft Office through Click-to-Run (Quick Repair with Online Repair fallback).

--- a/tools/Uninstall-Office.ps1
+++ b/tools/Uninstall-Office.ps1
@@ -1,4 +1,4 @@
-﻿function Uninstall-Office {
+function Uninstall-Office {
     <#
     .SYNOPSIS
         Completely removes Microsoft Office. Uses Get Help on Windows 11 23H2+ and direct removal on earlier versions.

--- a/tools/VideoDriverReinstall.ps1
+++ b/tools/VideoDriverReinstall.ps1
@@ -1,4 +1,4 @@
-﻿function VideoDriverReinstall {
+function VideoDriverReinstall {
     <#
     .SYNOPSIS
         Reinstalls or repairs video drivers with DDU in Safe Mode.

--- a/tools/WinBackupDriver.ps1
+++ b/tools/WinBackupDriver.ps1
@@ -1,4 +1,4 @@
-﻿function WinBackupDriver {
+function WinBackupDriver {
     <#
     .SYNOPSIS
         Creates a complete backup of Windows system drivers.

--- a/tools/WinCleaner.ps1
+++ b/tools/WinCleaner.ps1
@@ -1,4 +1,4 @@
-﻿function WinCleaner {
+function WinCleaner {
     <#
     .SYNOPSIS
         Automatically performs a complete Windows system cleanup.

--- a/tools/WinDebloat.ps1
+++ b/tools/WinDebloat.ps1
@@ -1,4 +1,4 @@
-﻿function WinDebloat {
+function WinDebloat {
     <#
     .SYNOPSIS
         Optimizes the system by disabling unnecessary services.

--- a/tools/WinDeleteUserProfiles.ps1
+++ b/tools/WinDeleteUserProfiles.ps1
@@ -1,4 +1,4 @@
-﻿function WinDeleteUserProfiles {
+function WinDeleteUserProfiles {
     <#
     .SYNOPSIS
         Safely removes unloaded local user profiles and residual folders from C:\Users.

--- a/tools/WinExportLog.ps1
+++ b/tools/WinExportLog.ps1
@@ -1,4 +1,4 @@
-﻿function WinExportLog {
+function WinExportLog {
     <#
     .SYNOPSIS
         Compresses WinToolkit logs and saves them to the Desktop for diagnostic submission.

--- a/tools/WinReinstallStore.ps1
+++ b/tools/WinReinstallStore.ps1
@@ -1,4 +1,4 @@
-﻿function WinReinstallStore {
+function WinReinstallStore {
     <#
     .SYNOPSIS
         Automatically reinstalls Microsoft Store on Windows 10/11 using Winget.

--- a/tools/WinRepairToolkit.ps1
+++ b/tools/WinRepairToolkit.ps1
@@ -1,4 +1,4 @@
-﻿function WinRepairToolkit {
+function WinRepairToolkit {
     <#
     .SYNOPSIS
         Runs standard Windows repairs (SFC, DISM, and Chkdsk) and saves Scannow logs in the toolkit folder for additional debugging.

--- a/tools/WinUpdateReset.ps1
+++ b/tools/WinUpdateReset.ps1
@@ -1,4 +1,4 @@
-﻿function WinUpdateReset {
+function WinUpdateReset {
     <#
     .SYNOPSIS
         Repairs Windows Update components and resets services, registry settings, and policies to their defaults.


### PR DESCRIPTION
## Descrizione

Fix Get-ToolkitLanguageDirectory in WinToolkit-template.ps1 to correctly resolve $PSScriptRoot with a fallback to (Get-Location).Path when null, preventing incorrect path resolution.


---

## Tipo di Modifica

<!-- Seleziona tutti i tipi applicabili -->
- [x] 🐛 Bug fix
- [ ] ✨ Nuova feature
- [ ] ♻️ Refactoring (nessun cambio funzionale)
- [ ] 🧹 Pulizia / Manutenzione
- [ ] 📖 Documentazione

---

## File Modificati

<!-- Elenca ogni file con una riga di descrizione -->
- `tool/NomeFile.ps1` — descrizione della modifica

---

## Test & Verifica

- [ ] Verificato localmente tramite `compiler.ps1`
- [ ] Log di esecuzione allegati (snippet o screenshot)

<details>
<summary>Log / Screenshot</summary>

```
Incolla qui i log rilevanti
```

</details>

---

## Checklist

> L'assenza di una spunta o la violazione di una regola comporta il rifiuto automatico della PR.

- [ ] PR indirizzata a `DEV` — le PR verso `main` vengono chiuse immediatamente
- [ ] Modifica atomica: un solo problema o una sola feature per PR
- [ ] `WinToolkit.ps1` **non** modificato manualmente (gestito dall'automazione CI)
- [ ] Modificati solo file in `/tool/*.ps1` o `WinToolkit-template.ps1`
- [ ] Stile di codice esistente rispettato, nessun debug code lasciato
- [ ] Commit chiari in italiano, max 72 caratteri per riga
