### PR TITLE
Enhancement start ps1 block only on update install

### DIFF
--- a/start.ps1
+++ b/start.ps1
@@ -108,37 +108,6 @@ catch {
 $pwsh = Get-WorkingPwsh
 if (-not $pwsh) { $pwsh = Install-Pwsh }
 
-function Test-WindowsUpdateBlocked {
-    # Returns $true ONLY while Windows updates are actually being installed.
-    # A pending reboot, downloaded-but-not-installed updates, a mere download
-    # phase, or a stale Windows Update history entry must NOT block the
-    # launcher: per design it proceeds in every case except a real
-    # installation currently in progress.
-
-    # The CBS worker (TiWorker.exe) runs only while updates are really being
-    # installed/staged, so it is the reliable "installazione in corso" signal.
-    # A pure download phase (or any other state) does not start it, so the
-    # launcher proceeds in all those cases.
-    if (Get-Process -Name 'TiWorker' -ErrorAction SilentlyContinue) {
-        return $true
-    }
-
-    return $false
-}
-
-Write-Host ''
-Write-Host 'Checking Windows update installation...' -ForegroundColor Cyan
-Write-Host 'Startup is suspended ONLY while updates are actually installing.' -ForegroundColor Yellow
-
-while (Test-WindowsUpdateBlocked) {
-    Write-Host ''
-    Write-Host "Windows updates are still installing. Re-checking in 5 seconds..." -ForegroundColor Yellow
-    Start-Sleep -Seconds 5
-}
-
-Write-Host ''
-Write-Host 'No update installation in progress. Continuing.' -ForegroundColor Green
-
 $coreCommand = '$s = irm ''' + $CoreScriptUrl + '''; & ([scriptblock]::Create($s))'
 $coreProcess = Start-Process -FilePath $pwsh -ArgumentList @(
     '-NoLogo', '-NoProfile', '-ExecutionPolicy', 'Bypass', '-Command', $coreCommand

--- a/start.ps1
+++ b/start.ps1
@@ -74,7 +74,7 @@ if (-not (Test-IsAdministrator)) {
     $elevatedHost = Get-WorkingPwsh
     if (-not $elevatedHost) { $elevatedHost = Install-Pwsh }
     if (-not $elevatedHost) {
-        Write-Error "Impossibile trovare o installare PowerShell 7 richiesto per continuare."
+        Write-Error "Could not find or install the required PowerShell 7 to continue."
         Read-Host -Prompt 'Premi INVIO per chiudere'
         exit 1
     }
@@ -93,7 +93,7 @@ try {
 }
 catch {
     Write-Error "`$_"
-    Read-Host -Prompt 'Elevazione fallita. Premi INVIO per chiudere'
+    Read-Host -Prompt 'Elevation failed. Press ENTER to close'
     exit 1
 }
 "@
@@ -109,10 +109,12 @@ $pwsh = Get-WorkingPwsh
 if (-not $pwsh) { $pwsh = Install-Pwsh }
 
 function Test-WindowsUpdateBlocked {
-    # Returns $true when Windows updates are still in progress or a reboot is
-    # still pending, which means dependency/core installation must be blocked.
+    # Returns $true ONLY when Windows updates are actually being installed
+    # (or a reboot is still pending after an install). A pure download phase
+    # is NOT a blocker: the launcher must proceed in every other case.
 
     # 1. Reboot still required (CBS / Windows Update / pending file renames).
+    #    Proceeding could conflict with queued servicing, so keep blocking.
     $rebootPending =
         (Test-Path 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Component Based Servicing\RebootPending') -or
         (Test-Path 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\Auto Update\RebootRequired') -or
@@ -120,7 +122,16 @@ function Test-WindowsUpdateBlocked {
 
     if ($rebootPending) { return $true }
 
-    # 2. Updates still being installed right now (operation in progress).
+    # 2. A servicing/installation worker is actively running. The CBS worker
+    #    (TiWorker.exe) runs only while updates are really being installed,
+    #    so this is the reliable "installazione in corso" signal. A download
+    #    (or a pending/downloaded-but-not-installed update) does not start it.
+    if (Get-Process -Name 'TiWorker' -ErrorAction SilentlyContinue) {
+        return $true
+    }
+
+    # 3. An installation operation still recorded as in progress in the
+    #    Windows Update history.
     try {
         $session  = New-Object -ComObject Microsoft.Update.Session
         $searcher = $session.CreateUpdateSearcher()
@@ -135,12 +146,6 @@ function Test-WindowsUpdateBlocked {
                 }
             }
         }
-
-        # 3. Pending software updates not yet installed.
-        $result = $searcher.Search("IsInstalled=0 and Type='Software'")
-        if ($result -and $result.Updates -and $result.Updates.Count -gt 0) {
-            return $true
-        }
     }
     catch {
         # If the Windows Update API cannot be queried, be conservative and block.
@@ -151,18 +156,18 @@ function Test-WindowsUpdateBlocked {
 }
 
 Write-Host ''
-Write-Host 'Controllo aggiornamenti di Windows in corso...' -ForegroundColor Cyan
-Write-Host 'Per evitare conflitti, l''installazione delle dipendenze e di start-core' -ForegroundColor Yellow
-Write-Host 'resta sospesa finche'' gli aggiornamenti di Windows non risultano completati.' -ForegroundColor Yellow
+Write-Host 'Checking Windows update installation...' -ForegroundColor Cyan
+Write-Host 'Startup is suspended ONLY while updates are actually installing' -ForegroundColor Yellow
+Write-Host '(or a reboot is pending). Downloading updates does not block.' -ForegroundColor Yellow
 
 while (Test-WindowsUpdateBlocked) {
     Write-Host ''
-    Write-Host "Aggiornamenti di Windows ancora in corso o riavvio necessario. Nuovo controllo tra 5 secondi..." -ForegroundColor Yellow
+    Write-Host "Windows updates are still installing or a reboot is required. Re-checking in 5 seconds..." -ForegroundColor Yellow
     Start-Sleep -Seconds 5
 }
 
 Write-Host ''
-Write-Host 'Aggiornamenti di Windows completati. Prosecuzione dell''installazione.' -ForegroundColor Green
+Write-Host 'No update installation in progress. Continuing.' -ForegroundColor Green
 
 $coreCommand = '$s = irm ''' + $CoreScriptUrl + '''; & ([scriptblock]::Create($s))'
 $coreProcess = Start-Process -FilePath $pwsh -ArgumentList @(

--- a/start.ps1
+++ b/start.ps1
@@ -110,39 +110,17 @@ if (-not $pwsh) { $pwsh = Install-Pwsh }
 
 function Test-WindowsUpdateBlocked {
     # Returns $true ONLY while Windows updates are actually being installed.
-    # A pending reboot, downloaded-but-not-installed updates, or a simple
-    # download phase must NOT block the launcher: per design it proceeds in
-    # every case except a real installation currently in progress.
+    # A pending reboot, downloaded-but-not-installed updates, a mere download
+    # phase, or a stale Windows Update history entry must NOT block the
+    # launcher: per design it proceeds in every case except a real
+    # installation currently in progress.
 
-    # 1. A servicing/installation worker is actively running. The CBS worker
-    #    (TiWorker.exe) runs only while updates are really being installed,
-    #    so this is the reliable "installazione in corso" signal. A download
-    #    (or a pending/downloaded-but-not-installed update) does not start it.
+    # The CBS worker (TiWorker.exe) runs only while updates are really being
+    # installed/staged, so it is the reliable "installazione in corso" signal.
+    # A pure download phase (or any other state) does not start it, so the
+    # launcher proceeds in all those cases.
     if (Get-Process -Name 'TiWorker' -ErrorAction SilentlyContinue) {
         return $true
-    }
-
-    # 2. An installation operation still recorded as in progress in the
-    #    Windows Update history.
-    try {
-        $session  = New-Object -ComObject Microsoft.Update.Session
-        $searcher = $session.CreateUpdateSearcher()
-
-        $count = $searcher.GetTotalHistoryCount()
-        if ($count -gt 0) {
-            $history = $searcher.QueryHistory(0, $count)
-            foreach ($entry in $history) {
-                # Operation 1 = installation, ResultCode 1 = still in progress.
-                if ($entry.Operation -eq 1 -and $entry.ResultCode -eq 1) {
-                    return $true
-                }
-            }
-        }
-    }
-    catch {
-        # If the Windows Update API cannot be queried, do NOT block: only a
-        # genuine running installation should stop the launcher.
-        return $false
     }
 
     return $false

--- a/start.ps1
+++ b/start.ps1
@@ -109,20 +109,12 @@ $pwsh = Get-WorkingPwsh
 if (-not $pwsh) { $pwsh = Install-Pwsh }
 
 function Test-WindowsUpdateBlocked {
-    # Returns $true ONLY when Windows updates are actually being installed
-    # (or a reboot is still pending after an install). A pure download phase
-    # is NOT a blocker: the launcher must proceed in every other case.
+    # Returns $true ONLY while Windows updates are actually being installed.
+    # A pending reboot, downloaded-but-not-installed updates, or a simple
+    # download phase must NOT block the launcher: per design it proceeds in
+    # every case except a real installation currently in progress.
 
-    # 1. Reboot still required (CBS / Windows Update / pending file renames).
-    #    Proceeding could conflict with queued servicing, so keep blocking.
-    $rebootPending =
-        (Test-Path 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Component Based Servicing\RebootPending') -or
-        (Test-Path 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\Auto Update\RebootRequired') -or
-        ((Get-ItemProperty 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager' -Name PendingFileRenameOperations -ErrorAction SilentlyContinue).PendingFileRenameOperations)
-
-    if ($rebootPending) { return $true }
-
-    # 2. A servicing/installation worker is actively running. The CBS worker
+    # 1. A servicing/installation worker is actively running. The CBS worker
     #    (TiWorker.exe) runs only while updates are really being installed,
     #    so this is the reliable "installazione in corso" signal. A download
     #    (or a pending/downloaded-but-not-installed update) does not start it.
@@ -130,7 +122,7 @@ function Test-WindowsUpdateBlocked {
         return $true
     }
 
-    # 3. An installation operation still recorded as in progress in the
+    # 2. An installation operation still recorded as in progress in the
     #    Windows Update history.
     try {
         $session  = New-Object -ComObject Microsoft.Update.Session
@@ -148,8 +140,9 @@ function Test-WindowsUpdateBlocked {
         }
     }
     catch {
-        # If the Windows Update API cannot be queried, be conservative and block.
-        return $true
+        # If the Windows Update API cannot be queried, do NOT block: only a
+        # genuine running installation should stop the launcher.
+        return $false
     }
 
     return $false
@@ -157,12 +150,11 @@ function Test-WindowsUpdateBlocked {
 
 Write-Host ''
 Write-Host 'Checking Windows update installation...' -ForegroundColor Cyan
-Write-Host 'Startup is suspended ONLY while updates are actually installing' -ForegroundColor Yellow
-Write-Host '(or a reboot is pending). Downloading updates does not block.' -ForegroundColor Yellow
+Write-Host 'Startup is suspended ONLY while updates are actually installing.' -ForegroundColor Yellow
 
 while (Test-WindowsUpdateBlocked) {
     Write-Host ''
-    Write-Host "Windows updates are still installing or a reboot is required. Re-checking in 5 seconds..." -ForegroundColor Yellow
+    Write-Host "Windows updates are still installing. Re-checking in 5 seconds..." -ForegroundColor Yellow
     Start-Sleep -Seconds 5
 }
 


### PR DESCRIPTION
## Description

<!-- Explain what changed and why. Be concise but complete. -->

Fixes # <!-- Remove if no linked issue -->

---

## Type of Change

<!-- Select all applicable types -->
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactoring (no functional change)
- [ ] 🧹 Cleanup / Maintenance
- [ ] 📖 Documentation

---

## Files Modified

<!-- List every file with a one-line description -->
- `tools/NomeFile.ps1` — description of the change

---

## Tests & Verification

- [ ] Verified locally via the relevant build/test command
- [ ] If CI/CD changed, validated the affected workflow/action and updated the tracking document
- [ ] Execution logs attached (snippet or screenshot)

<details>
<summary>Log / Screenshot</summary>

```
Paste relevant logs here
```

</details>

---

## Checklist

> Missing a checkbox or violating a rule will result in automatic PR rejection.

- [ ] PR targets `Dev` unless this is an authorized maintainer release change
- [ ] Atomic change: one issue or one feature per PR
- [ ] `WinToolkit.ps1` **not** modified manually (handled by CI automation)
- [ ] Generated artifacts (`WinToolkit.ps1`, `start-core.ps1`) are not edited manually
- [ ] Changes to `.github/`, `start.ps1` or `start-modules/` include the required maintainer review
- [ ] Existing code style respected, no debug code left behind
- [ ] Clear commits in Italian, max 72 characters per line
