### PR TITLE
The host is not transcribing

### DIFF
--- a/start-core.ps1
+++ b/start-core.ps1
@@ -616,7 +616,9 @@ function Initialize-UpdateServicesState {
         if ($previous.LastError) { $message += " Previous error: $($previous.LastError)" }
         Write-ToolkitLog -Level 'WARNING' -Message $message
         Write-StyledMessage -Type Warning -Text 'Rilevata una precedente interruzione: ripristino dello stato dei servizi Windows Update.'
-        Invoke-StartUpdateServices
+        if (-not (Invoke-StartUpdateServices)) {
+            Write-Warning "Ripristino servizi Windows Update non riuscito."
+        }
     }
 }
 function Set-UpdateServicesError {
@@ -2088,9 +2090,13 @@ function Invoke-WinToolkitSetup {
         return
     }
     finally {
-        Invoke-StartUpdateServices
-        try { Stop-Transcript -ErrorAction SilentlyContinue } catch {
-            Write-Warning "start-modules\90-Skeleton.Main.ps1, Invoke-WinToolkitSetup: $($_.Exception.Message)"
+        if (-not (Invoke-StartUpdateServices)) {
+            Write-Warning "Ripristino servizi Windows Update non riuscito."
+        }
+        try {
+            Stop-Transcript -ErrorAction SilentlyContinue
+        } catch {
+            Write-Warning "start-modules\90-Skeleton.Main.ps1, Invoke-WinToolkitSetup 2: $($_.Exception.Message)"
         }
         $ErrorActionPreference = $previousErrorActionPreference
     }

--- a/start-core.ps1
+++ b/start-core.ps1
@@ -109,7 +109,12 @@ function Write-StyledMessage {
 }
 function Start-ToolkitLog {
     param([string]$ToolName)
-    try { Stop-Transcript -ErrorAction SilentlyContinue } catch {
+    try {
+        Stop-Transcript -ErrorAction Stop | Out-Null
+    }
+    catch [System.Management.Automation.PSInvalidOperationException] {
+    }
+    catch {
         Write-Warning "start-modules\10-Module.Logging.ps1, Start-ToolkitLog: $($_.Exception.Message)"
     }
     $dateTime = Get-Date -Format "yyyy-MM-dd_HH-mm-ss"

--- a/start-modules/10-Module.Logging.ps1
+++ b/start-modules/10-Module.Logging.ps1
@@ -35,7 +35,13 @@ function Start-ToolkitLog {
     param([string]$ToolName)
 
     # Clean up leftover transcripts
-    try { Stop-Transcript -ErrorAction SilentlyContinue } catch {
+    try {
+        Stop-Transcript -ErrorAction Stop | Out-Null
+    }
+    catch [System.Management.Automation.PSInvalidOperationException] {
+        # An error occurred stopping transcription: The host is not currently transcribing.
+    }
+    catch {
         Write-Warning "start-modules\10-Module.Logging.ps1, Start-ToolkitLog: $($_.Exception.Message)"
     }
 

--- a/start-modules/10-Module.Logging.ps1
+++ b/start-modules/10-Module.Logging.ps1
@@ -34,15 +34,13 @@ function Start-ToolkitLog {
     #>
     param([string]$ToolName)
 
-    # Clean up leftover transcripts
-    try {
-        Stop-Transcript -ErrorAction Stop | Out-Null
-    }
-    catch [System.Management.Automation.PSInvalidOperationException] {
-        # Issue #173: An error occurred stopping transcription: The host is not currently transcribing.
-    }
-    catch {
-        Write-Warning "start-modules\10-Module.Logging.ps1, Start-ToolkitLog: $($_.Exception.Message)"
+    # Clean up leftover transcripts. Stop-Transcript throws when no transcript is
+    # active ("The host is not currently transcribing"), which is expected on a
+    # fresh run, so that benign case is silenced instead of surfaced as a warning.
+    try { Stop-Transcript -ErrorAction SilentlyContinue } catch {
+        if ($_.Exception.Message -notmatch 'not currently transcribing') {
+            Write-Warning "start-modules\10-Module.Logging.ps1, Start-ToolkitLog: $($_.Exception.Message)"
+        }
     }
 
     $dateTime = Get-Date -Format "yyyy-MM-dd_HH-mm-ss"

--- a/start-modules/10-Module.Logging.ps1
+++ b/start-modules/10-Module.Logging.ps1
@@ -39,7 +39,7 @@ function Start-ToolkitLog {
         Stop-Transcript -ErrorAction Stop | Out-Null
     }
     catch [System.Management.Automation.PSInvalidOperationException] {
-        # An error occurred stopping transcription: The host is not currently transcribing.
+        # Issue #173: An error occurred stopping transcription: The host is not currently transcribing.
     }
     catch {
         Write-Warning "start-modules\10-Module.Logging.ps1, Start-ToolkitLog: $($_.Exception.Message)"

--- a/start-modules/30-Module.Environment.ps1
+++ b/start-modules/30-Module.Environment.ps1
@@ -282,6 +282,7 @@ function Read-UpdateServicesStatus {
     }
 }
 
+
 function Initialize-UpdateServicesState {
     $previous = Read-UpdateServicesStatus
     if (-not $previous) { return }
@@ -291,9 +292,13 @@ function Initialize-UpdateServicesState {
         if ($previous.LastError) { $message += " Previous error: $($previous.LastError)" }
         Write-ToolkitLog -Level 'WARNING' -Message $message
         Write-StyledMessage -Type Warning -Text 'Rilevata una precedente interruzione: ripristino dello stato dei servizi Windows Update.'
-        Invoke-StartUpdateServices
+        
+        if (-not (Invoke-StartUpdateServices)) {
+            Write-Warning "Ripristino servizi Windows Update non riuscito."
+        }
     }
 }
+
 
 function Set-UpdateServicesError {
     param([string]$Message)

--- a/start-modules/90-Skeleton.Main.ps1
+++ b/start-modules/90-Skeleton.Main.ps1
@@ -170,9 +170,14 @@ function Invoke-WinToolkitSetup {
         return
     }
     finally {
-        Invoke-StartUpdateServices
-        try { Stop-Transcript -ErrorAction SilentlyContinue } catch {
-            Write-Warning "start-modules\90-Skeleton.Main.ps1, Invoke-WinToolkitSetup: $($_.Exception.Message)"
+        if (-not (Invoke-StartUpdateServices)) {
+            Write-Warning "Ripristino servizi Windows Update non riuscito."
+        }
+        
+        try {
+            Stop-Transcript -ErrorAction SilentlyContinue
+        } catch {
+            Write-Warning "start-modules\90-Skeleton.Main.ps1, Invoke-WinToolkitSetup 2: $($_.Exception.Message)"
         }
         $ErrorActionPreference = $previousErrorActionPreference
     }


### PR DESCRIPTION
## Description

<!-- Explain what changed and why. Be concise but complete. -->

Fixes # <!-- Remove if no linked issue -->

- #173 
- "True" value showed at the end of winstart.
---

## Type of Change

<!-- Select all applicable types -->
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactoring (no functional change)
- [ ] 🧹 Cleanup / Maintenance
- [ ] 📖 Documentation

---

## Files Modified

<!-- List every file with a one-line description -->
- `start-modules/10-Module.Logging.ps1` — #173 
- `start-modules/30-Module.Environment.ps1` — Fix True value showed at the end of winstart.
- `start-modules/90-Skeleton.Main.ps1` — Fix True value showed at the end of winstart.

---

## Tests & Verification

- [x] Verified locally via the relevant build/test command
- [x] If CI/CD changed, validated the affected workflow/action and updated the tracking document
- [x] Execution logs attached (snippet or screenshot)

<details>
<summary>Log / Screenshot</summary>

```
Paste relevant logs here
```

</details>

---

## Checklist

> Missing a checkbox or violating a rule will result in automatic PR rejection.

- [x] PR targets `Dev` unless this is an authorized maintainer release change
- [x] Atomic change: one issue or one feature per PR
- [x] `WinToolkit.ps1` **not** modified manually (handled by CI automation)
- [x] Generated artifacts (`WinToolkit.ps1`, `start-core.ps1`) are not edited manually
- [x] Changes to `.github/`, `start.ps1` or `start-modules/` include the required maintainer review
- [x] Existing code style respected, no debug code left behind
- [x] Clear commits in Italian, max 72 characters per line
