### PR TITLE
173 bug an error occurred stopping transcription the host is not currently transcribing

### DIFF
--- a/start-modules/10-Module.Logging.ps1
+++ b/start-modules/10-Module.Logging.ps1
@@ -34,9 +34,13 @@ function Start-ToolkitLog {
     #>
     param([string]$ToolName)
 
-    # Clean up leftover transcripts
+    # Clean up leftover transcripts. Stop-Transcript throws when no transcript is
+    # active ("The host is not currently transcribing"), which is expected on a
+    # fresh run, so that benign case is silenced instead of surfaced as a warning.
     try { Stop-Transcript -ErrorAction SilentlyContinue } catch {
-        Write-Warning "start-modules\10-Module.Logging.ps1, Start-ToolkitLog: $($_.Exception.Message)"
+        if ($_.Exception.Message -notmatch 'not currently transcribing') {
+            Write-Warning "start-modules\10-Module.Logging.ps1, Start-ToolkitLog: $($_.Exception.Message)"
+        }
     }
 
     $dateTime = Get-Date -Format "yyyy-MM-dd_HH-mm-ss"

--- a/start-modules/90-Skeleton.Main.ps1
+++ b/start-modules/90-Skeleton.Main.ps1
@@ -177,7 +177,9 @@ function Invoke-WinToolkitSetup {
     finally {
         Invoke-StartUpdateServices
         try { Stop-Transcript -ErrorAction SilentlyContinue } catch {
-            Write-Warning "start-modules\90-Skeleton.Main.ps1, Invoke-WinToolkitSetup: $($_.Exception.Message)"
+            if ($_.Exception.Message -notmatch 'not currently transcribing') {
+                Write-Warning "start-modules\90-Skeleton.Main.ps1, Invoke-WinToolkitSetup: $($_.Exception.Message)"
+            }
         }
         $ErrorActionPreference = $previousErrorActionPreference
     }

--- a/start-modules/90-Skeleton.Main.ps1
+++ b/start-modules/90-Skeleton.Main.ps1
@@ -30,6 +30,15 @@ function Invoke-WinToolkitSetup {
 
         # Initialize Logging
         Start-ToolkitLog "WinToolkitStarter"
+
+        # Localization must be resolved before any path that emits translated
+        # messages. In particular, Initialize-UpdateServicesState can trigger an
+        # early Windows Update service restore (when a previous run left a
+        # RestoreFailed state) and that restore prints translation keys such as
+        # uiText.resettingWindowsUpdateServices. Resolving first prevents
+        # "[MISSING TRANSLATION]" warnings during that startup recovery.
+        $null = Resolve-SourceTextLanguage -RequestedLanguage $Language
+
         Initialize-UpdateServicesState
 
         if ($PSVersionTable.PSVersion.Major -lt 7) {
@@ -38,10 +47,6 @@ function Invoke-WinToolkitSetup {
         if (-not ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
             throw 'start-core.ps1 must be started by the elevated start.ps1 stub.'
         }
-
-        # Localization is prepared here, after logging exists and after the
-        # elevation check, so the GitHub API is never queried twice per run.
-        $null = Resolve-SourceTextLanguage -RequestedLanguage $Language
 
         Show-Header -Title $script:AppConfig.Header.Title -Version $script:AppConfig.Header.Version
 


### PR DESCRIPTION
## Description

<!-- Explain what changed and why. Be concise but complete. -->

Fixes # <!-- Remove if no linked issue -->

---

## Type of Change

<!-- Select all applicable types -->
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactoring (no functional change)
- [ ] 🧹 Cleanup / Maintenance
- [ ] 📖 Documentation

---

## Files Modified

<!-- List every file with a one-line description -->
- `tools/NomeFile.ps1` — description of the change

---

## Tests & Verification

- [ ] Verified locally via the relevant build/test command
- [ ] If CI/CD changed, validated the affected workflow/action and updated the tracking document
- [ ] Execution logs attached (snippet or screenshot)

<details>
<summary>Log / Screenshot</summary>

```
Paste relevant logs here
```

</details>

---

## Checklist

> Missing a checkbox or violating a rule will result in automatic PR rejection.

- [ ] PR targets `Dev` unless this is an authorized maintainer release change
- [ ] Atomic change: one issue or one feature per PR
- [ ] `WinToolkit.ps1` **not** modified manually (handled by CI automation)
- [ ] Generated artifacts (`WinToolkit.ps1`, `start-core.ps1`) are not edited manually
- [ ] Changes to `.github/`, `start.ps1` or `start-modules/` include the required maintainer review
- [ ] Existing code style respected, no debug code left behind
- [ ] Clear commits in Italian, max 72 characters per line
